### PR TITLE
Ok, so I should've had inverted comma's when adding the "1.0.0" to the v...

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,5 @@
 {
     "name": "sarelvdwalt/db-archive-bundle",
-    "version": 1.0.0,
     "description": "Bundle to archive database tables using different strategies",
     "minimum-stability": "dev",
     "license": "MIT",


### PR DESCRIPTION
...ersion. Turns out when running validation:

14:04:18 sarel@sarel.local SFDatabaseArchiveBundle develop ? composerphar validate
./composer.json is valid, but with a few warnings
See http://getcomposer.org/doc/04-schema.md for details on the schema
The version field is present, it is recommended to leave it out if the package is published on Packagist.
